### PR TITLE
Add optional occurred_at and ttl fields to Event model

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,25 @@ EventBus.subscribers(:hello_received)
   id: String.t | integer(), # required
   transaction_id: String.t | integer(), # optional
   topic: atom(), # required
-  data: any() # required
+  data: any() # required,
+  occurred_at: integer(), # optional, might be seconds, milliseconds or microseconds even nano seconds since Elixir does not have a limit on integer size
+  ttl: integer() # optional, might be seconds, milliseconds or microseconds even nano seconds since Elixir does not have a limit on integer size. If `tll` field is set, it is recommended to set `occurred_at` field too.
 }
 ```
 
-**Why there is a `transaction_id` attribute on structure?**
+**About `transaction_id` attribute**
 
 Firstly, `transaction_id` attribute is an optional field, if you need to store any meta identifier related to event transaction, it is the place to store. Secondly, `transaction_id` is one of the good ways to track events related to the same transaction on a chain of events. If you have time, have a look to the [story](https://hackernoon.com/trace-monitor-chain-of-microservice-logs-in-the-same-transaction-f13420f2d42c).
+
+**About `occurred_at` attribute**
+
+Optional, but good to have field for all events to track when the event occurred with unixtimestamp value. The library does not automatically set this value since the value depends on the timing choice.
+
+**About `ttl` attribute**
+
+Optional, but might to have field for all events to invalidate an event after a certain amount of time. Currently, the `event_bus` library does not do any specific thing using this field. If you need to discard an event in a certain amount of time, that field would be very useful.
+
+Note: If you set this field, then `occurred_at` field is required.
 
 Define an event struct
 ```elixir

--- a/lib/event_bus/models/event.ex
+++ b/lib/event_bus/models/event.ex
@@ -5,12 +5,14 @@ defmodule EventBus.Model.Event do
 
   @enforce_keys [:id, :topic, :data]
 
-  defstruct [:id, :transaction_id, :topic, :data]
+  defstruct [:id, :transaction_id, :topic, :data, :occurred_at, :ttl]
 
   @type t :: %__MODULE__{
     id: String.t | integer,
     transaction_id: String.t | integer,
     topic: atom,
-    data: any
+    data: any,
+    occurred_at: integer,
+    ttl: integer
   }
 end

--- a/test/event_bus/event_manager_test.exs
+++ b/test/event_bus/event_manager_test.exs
@@ -32,7 +32,7 @@ defmodule EventBus.EventManagerTest do
       end)
 
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: [1, 2], id: \"E1\", topic: :metrics_received, transaction_id: \"T1\"}")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", topic: :metrics_summed, transaction_id: \"T1\"}")
+    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: [1, 2], id: \"E1\", occurred_at: nil, topic: :metrics_received, transaction_id: \"T1\", ttl: nil}")
+    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", occurred_at: nil, topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
   end
 end

--- a/test/event_bus_test.exs
+++ b/test/event_bus_test.exs
@@ -30,9 +30,10 @@ defmodule EventBusrTest do
 
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
-      " [1, 7], id: \"M1\", topic: :metrics_received, transaction_id: \"T1\"}")
+      " [1, 7], id: \"M1\", occurred_at: nil, topic: :metrics_received," <>
+      " transaction_id: \"T1\", ttl: nil}")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
-      " {8, [1, 7]}, id: \"E123\", topic: :metrics_summed," <>
-      " transaction_id: \"T1\"}")
+      " {8, [1, 7]}, id: \"E123\", occurred_at: nil, topic: :metrics_summed," <>
+      " transaction_id: \"T1\", ttl: nil}")
   end
 end


### PR DESCRIPTION
Add optional `occurred_at` and `ttl` fields to `Event` model to track and invalidate events when necessary.