### PR TITLE
Add source field to increase traceability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - Present
+
+### Added
+
+- Add `source` attribute to increase traceability
+
+### TODO
+
 ## [0.8.0] - 2018-01-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ EventBus.subscribers(:hello_received)
   data: any() # required,
   initialized_at: integer(), # optional, might be seconds, milliseconds or microseconds even nano seconds since Elixir does not have a limit on integer size
   occurred_at: integer(), # optional, might be seconds, milliseconds or microseconds even nano seconds since Elixir does not have a limit on integer size
+  source: String.t, # optional, source of the event, who created it
   ttl: integer() # optional, might be seconds, milliseconds or microseconds even nano seconds since Elixir does not have a limit on integer size. If `tll` field is set, it is recommended to set `occurred_at` field too.
 }
 ```
@@ -151,16 +152,18 @@ id = "some unique id"
 topic = :user_created
 transaction_id = "tx"
 ttl = 600_000
+source = "my event creator" # optional
 
-Event.build(id, topic, transaction_id, ttl) do
+Event.build(id, topic, transaction_id, ttl, source) do
   # do some calc in here
+  Process.sleep(1)
   # as a result return only the event data
   %{email: "jd@example.com", name: "John Doe"}
 end
 > %EventBus.Model.Event{data: %{email: "jd@example.com", name: "John Doe"},
- id: "some unique id", initialized_at: 1515235365129,
- occurred_at: 1515235365129, topic: :user_created, transaction_id: "tx",
- ttl: 600000}
+ id: "some unique id", initialized_at: 1515274599140,
+ occurred_at: 1515274599141, source: "my event creator", topic: :user_created,
+ transaction_id: "tx", ttl: 600000}
 ```
 
 **Use block notifier to notify event data to given topic**
@@ -174,10 +177,10 @@ id = "some unique id"
 topic = :user_created
 transaction_id = "tx" # optional
 ttl = 600_000 # optional
-
+source = "my event creator" # optional
 EventBus.register_topic(topic) # incase you didn't register it in `config.exs`
 
-Event.notify(id, topic, transaction_id, ttl) do
+Event.notify(id, topic, transaction_id, ttl, source) do
   # do some calc in here
   # as a result return only the event data
   %{email: "mrsjd@example.com", name: "Mrs Jane Doe"}
@@ -275,7 +278,13 @@ defmodule MyDataStore do
 end
 ```
 
-### Documentation
+## Traceability
+
+EventBus comes with a good enough data structure to track the event life cycle with its optional parameters. For a traceable system, it is highly recommend to fill optional fields on event data.
+
+Please refer to
+
+## Documentation
 
 Module docs can be found at [https://hexdocs.pm/event_bus](https://hexdocs.pm/event_bus).
 

--- a/lib/event_bus/models/event.ex
+++ b/lib/event_bus/models/event.ex
@@ -14,6 +14,7 @@ defmodule EventBus.Model.Event do
     :data,
     :initialized_at,
     :occurred_at,
+    :source,
     :ttl
   ]
 
@@ -26,6 +27,7 @@ defmodule EventBus.Model.Event do
   * :data - Context
   * :initialized_at - When the process initialized to generate this event
   * :occurred_at - When it is occurred
+  * :source - Who created this event: module, function or service name are good
   * :ttl - Time to live value
   """
   @type t :: %__MODULE__{
@@ -35,6 +37,7 @@ defmodule EventBus.Model.Event do
     data: any,
     initialized_at: integer,
     occurred_at: integer,
+    source: String.t,
     ttl: integer
   }
 
@@ -53,7 +56,8 @@ defmodule EventBus.Model.Event do
   @doc """
   Dynamic event builder block with auto initialized_at and occurred_at fields
   """
-  defmacro build(id, topic, transaction_id \\ nil, ttl \\ nil, do: yield) do
+  defmacro build(id, topic, transaction_id \\ nil, ttl \\ nil, source \\ nil,
+    do: yield) do
     quote do
       initialized_at = System.os_time(:milli_seconds)
       data = unquote(yield)
@@ -64,6 +68,7 @@ defmodule EventBus.Model.Event do
         data: data,
         initialized_at: initialized_at,
         occurred_at: System.os_time(:milli_seconds),
+        source: unquote(source) || "#{__MODULE__}",
         ttl: unquote(ttl)
       }
     end
@@ -72,7 +77,8 @@ defmodule EventBus.Model.Event do
   @doc """
   Dynamic event notifier block with auto initialized_at and occurred_at fields
   """
-  defmacro notify(id, topic, transaction_id \\ nil, ttl \\ nil, do: yield) do
+  defmacro notify(id, topic, transaction_id \\ nil, ttl \\ nil, source \\ nil,
+    do: yield) do
     quote do
       initialized_at = System.os_time(:milli_seconds)
       data = unquote(yield)
@@ -83,6 +89,7 @@ defmodule EventBus.Model.Event do
         data: data,
         initialized_at: initialized_at,
         occurred_at: System.os_time(:milli_seconds),
+        source: unquote(source) || "#{__MODULE__}",
         ttl: unquote(ttl)
       }
       EventBus.notify(event)

--- a/test/event_bus/event_manager_test.exs
+++ b/test/event_bus/event_manager_test.exs
@@ -8,7 +8,8 @@ defmodule EventBus.EventManagerTest do
   doctest EventBus.EventManager
 
   @topic :metrics_received
-  @event %Event{id: "E1", transaction_id: "T1", topic: @topic, data: [1, 2]}
+  @event %Event{id: "E1", transaction_id: "T1", topic: @topic, data: [1, 2],
+    source: "EventManagerTest"}
 
   setup do
     Process.sleep(100)
@@ -33,7 +34,7 @@ defmodule EventBus.EventManagerTest do
       end)
 
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: [1, 2], id: \"E1\", initialized_at: nil, occurred_at: nil, topic: :metrics_received, transaction_id: \"T1\", ttl: nil}")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", initialized_at: nil, occurred_at: nil, topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
+    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: [1, 2], id: \"E1\", initialized_at: nil, occurred_at: nil, source: \"EventManagerTest\", topic: :metrics_received, transaction_id: \"T1\", ttl: nil}")
+    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", initialized_at: nil, occurred_at: nil, source: \"Logger\", topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
   end
 end

--- a/test/event_bus/models/event_test.exs
+++ b/test/event_bus/models/event_test.exs
@@ -33,7 +33,27 @@ defmodule EventBus.Model.EventTest do
     assert Event.duration(event) == 0
   end
 
-  test "build" do
+  test "build with source" do
+    id = 1
+    topic = "user_created"
+    data = %{id: 1, name: "me", email: "me@example.com"}
+    transaction_id = "t1"
+    ttl = 100
+    event =
+      Event.build(id, topic, transaction_id, ttl, "me") do
+        data
+      end
+    assert event.data == data
+    assert event.id == id
+    assert event.topic == topic
+    assert event.transaction_id == transaction_id
+    assert event.ttl == ttl
+    assert event.source == "me"
+    refute is_nil(event.initialized_at)
+    refute is_nil(event.occurred_at)
+  end
+
+  test "build without source" do
     id = 1
     topic = "user_created"
     data = %{id: 1, name: "me", email: "me@example.com"}
@@ -48,6 +68,7 @@ defmodule EventBus.Model.EventTest do
     assert event.topic == topic
     assert event.transaction_id == transaction_id
     assert event.ttl == ttl
+    assert event.source == "Elixir.EventBus.Model.EventTest"
     refute is_nil(event.initialized_at)
     refute is_nil(event.occurred_at)
   end

--- a/test/event_bus_test.exs
+++ b/test/event_bus_test.exs
@@ -1,4 +1,4 @@
-defmodule EventBusrTest do
+defmodule EventBusTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
   alias EventBus.Model.Event
@@ -7,7 +7,7 @@ defmodule EventBusrTest do
   doctest EventBus.EventManager
 
   @event %Event{id: "M1", transaction_id: "T1", data: [1, 7],
-    topic: :metrics_received}
+    topic: :metrics_received, source: "EventBusTest"}
 
   setup do
     Enum.each(EventBus.subscribers(), fn subscriber ->
@@ -31,11 +31,12 @@ defmodule EventBusrTest do
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
       " [1, 7], id: \"M1\", initialized_at: nil, occurred_at: nil," <>
-      " topic: :metrics_received," <>
+      " source: \"EventBusTest\", topic: :metrics_received," <>
       " transaction_id: \"T1\", ttl: nil}")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
       " {8, [1, 7]}, id: \"E123\", initialized_at: nil, occurred_at: nil," <>
-      " topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
+      " source: \"Logger\", topic: :metrics_summed," <>
+      " transaction_id: \"T1\", ttl: nil}")
   end
 
   test "topic_exist? with an existent topic" do

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -21,7 +21,7 @@ defmodule EventBus.Support.Helper do
       sum = Enum.reduce(inputs, 0, &(&1 + &2))
       # create a new event if necessary
       new_event = %Event{id: "E123", transaction_id: event.transaction_id,
-        topic: :metrics_summed, data: {sum, inputs}}
+        topic: :metrics_summed, data: {sum, inputs}, source: "Logger"}
       EventBus.notify(new_event)
       EventBus.mark_as_completed({__MODULE__, :metrics_received, id})
     end


### PR DESCRIPTION
This PR increase event traceability by addition of `source` attribute to `EventBus.Model.Event` structure.