### PR TITLE
Add optional configuration to Subscriber to use the same module/funct…

### DIFF
--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -76,6 +76,11 @@ defmodule EventBus do
       EventBus.subscribe({MyEventListener, [".*"]})
       :ok
 
+      # For configurable listeners you can pass tuple of processor and config
+      my_config = %{}
+      EventBus.subscribe({{OtherListener, my_config}, [".*"]})
+      :ok
+
   """
   @spec subscribe(tuple()) :: :ok
   defdelegate subscribe(subscriber),
@@ -87,6 +92,11 @@ defmodule EventBus do
   ## Examples
 
       EventBus.unsubscribe(MyEventListener)
+      :ok
+
+      # For configurable listeners you must pass tuple of processor and config
+      my_config = %{}
+      EventBus.unsubscribe({{OtherListener, my_config}, [".*"]})
       :ok
 
   """
@@ -102,6 +112,10 @@ defmodule EventBus do
       EventBus.subscribers()
       [MyEventListener]
 
+      # One usual and one configured listener with its config
+      EventBus.subscribers()
+      [MyEventListener, {OtherListener, %{}}]
+
   """
   @spec subscribers() :: list(any())
   defdelegate subscribers,
@@ -114,6 +128,10 @@ defmodule EventBus do
 
       EventBus.subscribers(:metrics_received)
       [MyEventListener]
+
+      # One usual and one configured listener with its config
+      EventBus.subscribers(:metrics_received)
+      [MyEventListener, {OtherListener, %{}}]
 
   """
   @spec subscribers(atom() | String.t) :: list(any())
@@ -150,6 +168,12 @@ defmodule EventBus do
   ## Examples
 
       EventBus.mark_as_skipped({MyEventListener, :unmatched_occurred, "124"})
+
+      # For configurable listeners you must pass tuple of processor and config
+      my_config = %{}
+      listener = {OtherListener, my_config}
+      EventBus.mark_as_skipped({listener, :unmatched_occurred, "124"})
+      :ok
 
   """
   @spec mark_as_skipped(tuple()) :: no_return()

--- a/test/event_bus/event_manager_test.exs
+++ b/test/event_bus/event_manager_test.exs
@@ -3,8 +3,8 @@ defmodule EventBus.EventManagerTest do
   import ExUnit.CaptureLog
   alias EventBus.Model.Event
   alias EventBus.{EventManager, SubscriptionManager}
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
-    BadOne}
+  alias EventBus.Support.Helper.{InputLogger, Calculator, AnotherCalculator,
+    MemoryLeakerOne, BadOne}
   doctest EventBus.EventManager
 
   @topic :metrics_received
@@ -20,11 +20,14 @@ defmodule EventBus.EventManagerTest do
   end
 
   test "notify" do
-    SubscriptionManager.subscribe({InputLogger,
+    SubscriptionManager.subscribe({{InputLogger, %{}},
       ["metrics_received$", "metrics_summed$"]})
-    SubscriptionManager.subscribe({BadOne, [".*"]})
-    SubscriptionManager.subscribe({Calculator, ["metrics_received$"]})
-    SubscriptionManager.subscribe({MemoryLeakerOne, [".*"]})
+    SubscriptionManager.subscribe({{BadOne, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{Calculator, %{}}, ["metrics_received$"]})
+    SubscriptionManager.subscribe({{MemoryLeakerOne, %{}}, [".*"]})
+
+    # This processor/listener one has one config!!!
+    SubscriptionManager.subscribe({AnotherCalculator, ["metrics_received$"]})
     listeners = SubscriptionManager.subscribers(@topic)
 
     logs =
@@ -36,5 +39,6 @@ defmodule EventBus.EventManagerTest do
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: [1, 2], id: \"E1\", initialized_at: nil, occurred_at: nil, source: \"EventManagerTest\", topic: :metrics_received, transaction_id: \"T1\", ttl: nil}")
     assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", initialized_at: nil, occurred_at: nil, source: \"Logger\", topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
+    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data: {3, [1, 2]}, id: \"E123\", initialized_at: nil, occurred_at: nil, source: \"AnotherCalculator\", topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}")
   end
 end

--- a/test/event_bus/event_watcher_test.exs
+++ b/test/event_bus/event_watcher_test.exs
@@ -33,7 +33,8 @@ defmodule EventBus.EventWatcherTest do
     EventWatcher.register_topic(topic)
     Process.sleep(100)
 
-    processors = [InputLogger, Calculator, MemoryLeakerOne, BadOne]
+    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
+      {BadOne, %{}}]
     id = "E1"
 
     EventWatcher.create({processors, topic, id})
@@ -47,15 +48,17 @@ defmodule EventBus.EventWatcherTest do
     EventWatcher.register_topic(topic)
     Process.sleep(100)
 
-    processors = [InputLogger, Calculator, MemoryLeakerOne, BadOne]
+    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
+      {BadOne, %{}}]
     id = "E1"
 
     EventWatcher.create({processors, topic, id})
     Process.sleep(100)
-    EventWatcher.mark_as_completed({InputLogger, topic, id})
+    EventWatcher.mark_as_completed({{InputLogger, %{}}, topic, id})
     Process.sleep(100)
 
-    assert {processors, [InputLogger], []} == EventWatcher.fetch({topic, id})
+    assert {processors, [{InputLogger, %{}}], []} ==
+      EventWatcher.fetch({topic, id})
   end
 
   test "skip" do
@@ -63,14 +66,16 @@ defmodule EventBus.EventWatcherTest do
     EventWatcher.register_topic(topic)
     Process.sleep(100)
 
-    processors = [InputLogger, Calculator, MemoryLeakerOne, BadOne]
+    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
+      {BadOne, %{}}]
     id = "E1"
 
     EventWatcher.create({processors, topic, id})
     Process.sleep(100)
-    EventWatcher.mark_as_skipped({InputLogger, topic, id})
+    EventWatcher.mark_as_skipped({{InputLogger, %{}}, topic, id})
     Process.sleep(100)
 
-    assert {processors, [], [InputLogger]} == EventWatcher.fetch({topic, id})
+    assert {processors, [], [{InputLogger, %{}}]} ==
+      EventWatcher.fetch({topic, id})
   end
 end

--- a/test/event_bus/subscription_manager_test.exs
+++ b/test/event_bus/subscription_manager_test.exs
@@ -1,6 +1,7 @@
 defmodule EventBus.SubscriptionManagerTest do
   use ExUnit.Case, async: false
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne}
+  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
+    AnotherCalculator}
   alias EventBus.SubscriptionManager
   doctest EventBus.SubscriptionManager
 
@@ -17,55 +18,65 @@ defmodule EventBus.SubscriptionManagerTest do
   end
 
   test "subscribe" do
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({Calculator, [".*"]})
-    SubscriptionManager.subscribe({MemoryLeakerOne, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{Calculator, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{MemoryLeakerOne, %{}}, [".*"]})
+    SubscriptionManager.subscribe({AnotherCalculator, [".*"]})
     Process.sleep(300)
 
-    assert [{MemoryLeakerOne, [".*"]}, {Calculator, [".*"]},
-      {InputLogger, [".*"]}] == SubscriptionManager.subscribers()
+    assert [
+      {AnotherCalculator, [".*"]},
+      {{MemoryLeakerOne, %{}}, [".*"]},
+      {{Calculator, %{}}, [".*"]},
+      {{InputLogger, %{}}, [".*"]}
+    ] == SubscriptionManager.subscribers()
   end
 
   test "does not subscribe same listener" do
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
     Process.sleep(300)
 
-    assert [{InputLogger, [".*"]}] == SubscriptionManager.subscribers()
+    assert [{{InputLogger, %{}}, [".*"]}] == SubscriptionManager.subscribers()
   end
 
   test "unsubscribe" do
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({Calculator, [".*"]})
-    SubscriptionManager.subscribe({MemoryLeakerOne, [".*"]})
-    SubscriptionManager.unsubscribe(Calculator)
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{Calculator, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{MemoryLeakerOne, %{}}, [".*"]})
+    SubscriptionManager.subscribe({AnotherCalculator, [".*"]})
+    SubscriptionManager.unsubscribe({Calculator, %{}})
+    SubscriptionManager.unsubscribe(AnotherCalculator)
     Process.sleep(300)
 
-    assert [{MemoryLeakerOne, [".*"]}, {InputLogger, [".*"]}] ==
+    assert [{{MemoryLeakerOne, %{}}, [".*"]}, {{InputLogger, %{}}, [".*"]}] ==
       SubscriptionManager.subscribers()
   end
 
   test "register_topic auto subscribe workers" do
     topic = :auto_subscribed
 
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({Calculator, [".*"]})
-    SubscriptionManager.subscribe({MemoryLeakerOne, ["other_received$"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{Calculator, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{MemoryLeakerOne, %{}}, ["other_received$"]})
+    SubscriptionManager.subscribe({AnotherCalculator, [".*"]})
 
     SubscriptionManager.register_topic(topic)
 
     Process.sleep(300)
 
-    assert [InputLogger, Calculator] == SubscriptionManager.subscribers(topic)
+    assert [{InputLogger, %{}}, {Calculator, %{}}, AnotherCalculator] ==
+      SubscriptionManager.subscribers(topic)
   end
 
   test "unregister_topic delete subscribers" do
     topic = :auto_subscribed
 
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
-    SubscriptionManager.subscribe({Calculator, [".*"]})
-    SubscriptionManager.subscribe({MemoryLeakerOne, ["other_received$"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{Calculator, %{}}, [".*"]})
+    SubscriptionManager.subscribe({{MemoryLeakerOne, %{}}, ["other_received$"]})
+    SubscriptionManager.subscribe({AnotherCalculator, [".*"]})
 
     SubscriptionManager.register_topic(topic)
     SubscriptionManager.unregister_topic(topic)
@@ -75,26 +86,47 @@ defmodule EventBus.SubscriptionManagerTest do
   end
 
   test "subscribers" do
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
     Process.sleep(300)
 
-    assert [{InputLogger, [".*"]}] == SubscriptionManager.subscribers()
+    assert [{{InputLogger, %{}}, [".*"]}] == SubscriptionManager.subscribers()
   end
 
   test "subscribers with event type" do
-    SubscriptionManager.subscribe({InputLogger, [".*"]})
+    SubscriptionManager.subscribe({{InputLogger, %{}}, [".*"]})
     Process.sleep(300)
 
-    assert [InputLogger] == SubscriptionManager.subscribers(:metrics_received)
-    assert [InputLogger] == SubscriptionManager.subscribers(:metrics_summed)
+    assert [{InputLogger, %{}}] ==
+      SubscriptionManager.subscribers(:metrics_received)
+    assert [{InputLogger, %{}}] ==
+      SubscriptionManager.subscribers(:metrics_summed)
+  end
+
+  test "subscribers with event type and without config" do
+    SubscriptionManager.subscribe({AnotherCalculator, [".*"]})
+    Process.sleep(300)
+
+    assert [AnotherCalculator] ==
+      SubscriptionManager.subscribers(:metrics_received)
+    assert [AnotherCalculator] ==
+      SubscriptionManager.subscribers(:metrics_summed)
   end
 
   test "state persistency to Application environment" do
-    SubscriptionManager.subscribe({InputLogger, ["metrics_received",
+    SubscriptionManager.subscribe({{InputLogger, %{}}, ["metrics_received",
       "metrics_summed"]})
+    SubscriptionManager.subscribe({AnotherCalculator, ["metrics_received$"]})
     Process.sleep(300)
-    expected = {[{InputLogger, ["metrics_received", "metrics_summed"]}],
-      %{metrics_received: [InputLogger], metrics_summed: [InputLogger]}}
+    expected = {
+      [
+        {AnotherCalculator, ["metrics_received$"]},
+        {{InputLogger, %{}}, ["metrics_received", "metrics_summed"]}
+      ],
+      %{
+        metrics_received: [AnotherCalculator, {InputLogger, %{}}],
+        metrics_summed: [{InputLogger, %{}}]}
+      }
+
 
     assert expected == Application.get_env(:event_bus, :subscriptions)
   end

--- a/test/event_bus_test.exs
+++ b/test/event_bus_test.exs
@@ -17,10 +17,10 @@ defmodule EventBusTest do
   end
 
   test "notify" do
-    EventBus.subscribe({InputLogger, [".*"]})
-    EventBus.subscribe({BadOne, [".*"]})
-    EventBus.subscribe({Calculator, ["metrics_received"]})
-    EventBus.subscribe({MemoryLeakerOne, [".*"]})
+    EventBus.subscribe({{InputLogger, %{}}, [".*"]})
+    EventBus.subscribe({{BadOne, %{}}, [".*"]})
+    EventBus.subscribe({{Calculator, %{}}, ["metrics_received"]})
+    EventBus.subscribe({{MemoryLeakerOne, %{}}, [".*"]})
 
     logs =
       capture_log(fn ->

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -4,14 +4,33 @@ defmodule EventBus.Support.Helper do
   defmodule InputLogger do
     require Logger
 
-    def process({topic, id}) do
+    def process({config, topic, id}) do
       event = EventBus.fetch_event({topic, id})
       Logger.info(fn -> "Event log for #{inspect(event)}" end)
-      EventBus.mark_as_completed({__MODULE__, topic, id})
+      EventBus.mark_as_completed({{__MODULE__, config}, topic, id})
     end
   end
 
   defmodule Calculator do
+    require Logger
+
+    def process({config, :metrics_received, id}) do
+      event = EventBus.fetch_event({:metrics_received, id})
+      inputs = event.data
+      # handle an event
+      sum = Enum.reduce(inputs, 0, &(&1 + &2))
+      # create a new event if necessary
+      new_event = %Event{id: "E123", transaction_id: event.transaction_id,
+        topic: :metrics_summed, data: {sum, inputs}, source: "Logger"}
+      EventBus.notify(new_event)
+      EventBus.mark_as_completed({{__MODULE__, config}, :metrics_received, id})
+    end
+    def process({config, topic, id}) do
+      EventBus.mark_as_skipped({{__MODULE__, config}, topic, id})
+    end
+  end
+
+  defmodule AnotherCalculator do
     require Logger
 
     def process({:metrics_received, id}) do
@@ -21,7 +40,8 @@ defmodule EventBus.Support.Helper do
       sum = Enum.reduce(inputs, 0, &(&1 + &2))
       # create a new event if necessary
       new_event = %Event{id: "E123", transaction_id: event.transaction_id,
-        topic: :metrics_summed, data: {sum, inputs}, source: "Logger"}
+        topic: :metrics_summed, data: {sum, inputs},
+        source: "AnotherCalculator"}
       EventBus.notify(new_event)
       EventBus.mark_as_completed({__MODULE__, :metrics_received, id})
     end
@@ -42,17 +62,17 @@ defmodule EventBus.Support.Helper do
       GenServer.start_link(__MODULE__, [], name: __MODULE__)
     end
 
-    def process({:metrics_summed, id}) do
-      GenServer.cast(__MODULE__, {:metrics_summed, id})
+    def process({config, :metrics_summed, id}) do
+      GenServer.cast(__MODULE__, {config, :metrics_summed, id})
     end
-    def process({topic, id}) do
-      EventBus.mark_as_skipped({__MODULE__, topic, id})
+    def process({config, topic, id}) do
+      EventBus.mark_as_skipped({{__MODULE__, config}, topic, id})
     end
 
-    def handle_cast({:metrics_summed, id}, state) do
+    def handle_cast({config, :metrics_summed, id}, state) do
       event = EventBus.fetch_event({:metrics_summed, id})
       new_state = [event | state]
-      EventBus.mark_as_completed({__MODULE__, :metrics_summed, id})
+      EventBus.mark_as_completed({{__MODULE__, config}, :metrics_summed, id})
       {:noreply, new_state}
     end
   end


### PR DESCRIPTION
Add optional configuration to Subscriber to use the same module/function with different configurations to process the event. The aim of this change is increasing re-useability of the listener with several configurations. For example, this will allow writing an HTTP consumer or an AWS lambda caller function with different configurations.