### PR TITLE
Formatter (Elixir 1.6)

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 80
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move utility functions into its own module
 - Add addons section to README
 - Switch to microseconds when auto event structuring with `EventSource` to increase compability with Zipkin and Datadog APM
+- Error topic introduced for dynamic event builder/notifier with `EventSource`. Now you can pass `:error_topic` key, EvetSource automatically check the result of execution block for `{:error, _}` tuple and create an event structure for the given `:error_topic`.
 
 ## [0.9.0] - 2018-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add addons section to README
 - Switch to microseconds when auto event structuring with `EventSource` to increase compability with Zipkin and Datadog APM
 - Error topic introduced for dynamic event builder/notifier with `EventSource`. Now you can pass `:error_topic` key, EvetSource automatically check the result of execution block for `{:error, _}` tuple and create an event structure for the given `:error_topic`.
+- Add elixir formatter config to format code
 
 ## [0.9.0] - 2018-01-06
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ end
  transaction_id: nil, ttl: nil}
 ```
 
+# With optional error topic param
+params = %{id: id, topic: topic, error_topic: :user_create_erred}
+EventSource.build(params) do
+  {:error, %{email: "Invalid format"}}
+end
+> %EventBus.Model.Event{data: {:error, %{email: "Invalid format"}},
+ id: "some unique id", initialized_at: 1515274599140491000,
+ occurred_at: 1515274599141211000, source: nil, topic: :user_create_erred,
+ transaction_id: nil, ttl: nil}
+
 **Use block notifier to notify event data to given topic**
 
 Builder automatically sets initialized_at and occured_at attributes
@@ -200,12 +210,13 @@ use EventBus.EventSource
 
 id = "some unique id"
 topic = :user_created
+error_topic = :user_create_erred # optional (incase error tuple return in yield execution, it will use :error_topic value as :topic for event creation)
 transaction_id = "tx" # optional
 ttl = 600_000 # optional
 source = "my event creator" # optional
 EventBus.register_topic(topic) # incase you didn't register it in `config.exs`
 
-params = %{id: id, topic: topic, transaction_id: transaction_id, ttl: ttl, source: source}
+params = %{id: id, topic: topic, transaction_id: transaction_id, ttl: ttl, source: source, error_topic: error_topic}
 EventSource.notify(params) do
   # do some calc in here
   # as a result return only the event data

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :event_bus,
-  topics: [:metrics_received, :metrics_summed]
+config :event_bus, topics: [:metrics_received, :metrics_summed]

--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -4,8 +4,7 @@ defmodule EventBus do
   event watcher based on ETS
   """
 
-  alias EventBus.{Notifier, Store, Watcher, Subscription,
-    Topic, Model.Event}
+  alias EventBus.{Notifier, Store, Watcher, Subscription, Topic, Model.Event}
 
   @doc """
   Send event to all listeners.
@@ -18,9 +17,10 @@ defmodule EventBus do
       :ok
 
   """
-  @spec notify(Event.t) :: :ok
+  @spec notify(Event.t()) :: :ok
   defdelegate notify(event),
-    to: Notifier, as: :notify
+    to: Notifier,
+    as: :notify
 
   @doc """
   Check if topic registered.
@@ -31,9 +31,10 @@ defmodule EventBus do
       true
 
   """
-  @spec topic_exist?(String.t | atom()) :: boolean()
+  @spec topic_exist?(String.t() | atom()) :: boolean()
   defdelegate topic_exist?(topic),
-    to: Topic, as: :exist?
+    to: Topic,
+    as: :exist?
 
   @doc """
   List all registered topics.
@@ -45,7 +46,8 @@ defmodule EventBus do
   """
   @spec topics() :: list(atom())
   defdelegate topics,
-    to: Topic, as: :all
+    to: Topic,
+    as: :all
 
   @doc """
   Register a topic
@@ -56,9 +58,10 @@ defmodule EventBus do
       :ok
 
   """
-  @spec register_topic(String.t | atom()) :: boolean()
+  @spec register_topic(String.t() | atom()) :: boolean()
   defdelegate register_topic(topic),
-    to: Topic, as: :register
+    to: Topic,
+    as: :register
 
   @doc """
   Unregister a topic
@@ -69,9 +72,10 @@ defmodule EventBus do
       :ok
 
   """
-  @spec unregister_topic(String.t | atom()) :: boolean()
+  @spec unregister_topic(String.t() | atom()) :: boolean()
   defdelegate unregister_topic(topic),
-    to: Topic, as: :unregister
+    to: Topic,
+    as: :unregister
 
   @doc """
   Subscribe to the bus.
@@ -89,7 +93,8 @@ defmodule EventBus do
   """
   @spec subscribe(tuple()) :: :ok
   defdelegate subscribe(listener_with_topics),
-    to: Subscription, as: :subscribe
+    to: Subscription,
+    as: :subscribe
 
   @doc """
   Unsubscribe from the bus.
@@ -107,7 +112,8 @@ defmodule EventBus do
   """
   @spec unsubscribe({tuple() | module()}) :: :ok
   defdelegate unsubscribe(listener),
-    to: Subscription, as: :unsubscribe
+    to: Subscription,
+    as: :unsubscribe
 
   @doc """
   List the subscribers.
@@ -124,7 +130,8 @@ defmodule EventBus do
   """
   @spec subscribers() :: list(any())
   defdelegate subscribers,
-    to: Subscription, as: :subscribers
+    to: Subscription,
+    as: :subscribers
 
   @doc """
   List the subscribers to the with given topic.
@@ -139,9 +146,10 @@ defmodule EventBus do
       [MyEventListener, {OtherListener, %{}}]
 
   """
-  @spec subscribers(atom() | String.t) :: list(any())
+  @spec subscribers(atom() | String.t()) :: list(any())
   defdelegate subscribers(topic),
-    to: Subscription, as: :subscribers
+    to: Subscription,
+    as: :subscribers
 
   @doc """
   Fetch event data
@@ -151,9 +159,10 @@ defmodule EventBus do
       EventBus.fetch_event({:hello_received, "123"})
 
   """
-  @spec fetch_event({atom(), String.t | integer()}) :: Event.t
+  @spec fetch_event({atom(), String.t() | integer()}) :: Event.t()
   defdelegate fetch_event(event_shadow),
-    to: Store, as: :fetch
+    to: Store,
+    as: :fetch
 
   @doc """
   Send the event processing completed to the watcher
@@ -169,10 +178,11 @@ defmodule EventBus do
       :ok
 
   """
-  @spec mark_as_completed({tuple() | module(), atom(), String.t | integer()})
+  @spec mark_as_completed({tuple() | module(), atom(), String.t() | integer()})
     :: no_return()
   defdelegate mark_as_completed(listener_with_event_shadow),
-    to: Watcher, as: :mark_as_completed
+    to: Watcher,
+    as: :mark_as_completed
 
   @doc """
   Send the event processing skipped to the watcher
@@ -188,8 +198,9 @@ defmodule EventBus do
       :ok
 
   """
-  @spec mark_as_skipped({tuple() | module(), atom(), String.t | integer()})
+  @spec mark_as_skipped({tuple() | module(), atom(), String.t() | integer()})
     :: no_return()
   defdelegate mark_as_skipped(listener_with_event_shadow),
-    to: Watcher, as: :mark_as_skipped
+    to: Watcher,
+    as: :mark_as_skipped
 end

--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -20,26 +20,29 @@ defmodule EventBus.EventSource do
   defmacro build(params, do: yield) do
     quote do
       initialized_at = System.os_time(:micro_seconds)
-      params         = unquote(params)
-      source         = Map.get(params, :source,
-        String.replace("#{__MODULE__}", "Elixir.", ""))
-      {topic, data}  =
-      case unquote(yield) do
-        {:error, error} ->
-          {params[:error_topic] || params[:topic], {:error, error}}
-        result ->
-          {params[:topic], result}
-      end
+      params = unquote(params)
+
+      source =
+        Map.get(params, :source, String.replace("#{__MODULE__}", "Elixir.", ""))
+
+      {topic, data} =
+        case unquote(yield) do
+          {:error, error} ->
+            {params[:error_topic] || params[:topic], {:error, error}}
+
+          result ->
+            {params[:topic], result}
+        end
 
       %Event{
-        id:             params[:id],
-        topic:          topic,
+        id: params[:id],
+        topic: topic,
         transaction_id: params[:transaction_id],
-        data:           data,
+        data: data,
         initialized_at: initialized_at,
-        occurred_at:    System.os_time(:micro_seconds),
-        source:         source,
-        ttl:            params[:ttl]
+        occurred_at: System.os_time(:micro_seconds),
+        source: source,
+        ttl: params[:ttl]
       }
     end
   end
@@ -50,7 +53,7 @@ defmodule EventBus.EventSource do
   defmacro notify(params, do: yield) do
     quote do
       event =
-        EventSource.build(unquote(params)) do
+        EventSource.build unquote(params) do
           unquote(yield)
         end
 

--- a/lib/event_bus/models/event.ex
+++ b/lib/event_bus/models/event.ex
@@ -29,25 +29,28 @@ defmodule EventBus.Model.Event do
   * :ttl - Time to live value
   """
   @type t :: %__MODULE__{
-    id: String.t | integer,
-    transaction_id: String.t | integer,
-    topic: atom,
-    data: any,
-    initialized_at: integer,
-    occurred_at: integer,
-    source: String.t,
-    ttl: integer
-  }
+          id: String.t() | integer,
+          transaction_id: String.t() | integer,
+          topic: atom,
+          data: any,
+          initialized_at: integer,
+          occurred_at: integer,
+          source: String.t(),
+          ttl: integer
+        }
 
   @doc """
   Duration of the event, and simple answer of how long does it take to generate
   this event
   """
-  def duration(%__MODULE__{initialized_at: initialized_at,
-    occurred_at: occurred_at})
-    when is_integer(initialized_at) and is_integer(occurred_at) do
+  def duration(%__MODULE__{
+        initialized_at: initialized_at,
+        occurred_at: occurred_at
+      })
+      when is_integer(initialized_at) and is_integer(occurred_at) do
     occurred_at - initialized_at
   end
+
   def duration(_),
     do: 0
 end

--- a/lib/event_bus/notifier.ex
+++ b/lib/event_bus/notifier.ex
@@ -9,17 +9,24 @@ defmodule EventBus.Notifier do
   use GenServer
   alias EventBus.Model.Event
 
-  @backend Application.get_env(:event_bus, :notifier_backend,
-    EventBus.Service.Notifier)
+  @backend Application.get_env(
+             :event_bus,
+             :notifier_backend,
+             EventBus.Service.Notifier
+           )
 
   @doc false
   def start_link,
     do: GenServer.start_link(__MODULE__, nil, name: __MODULE__)
 
+  @doc false
+  def init(args),
+    do: {:ok, args}
+
   @doc """
   Notify event to its listeners
   """
-  @spec notify(Event.t) :: no_return()
+  @spec notify(Event.t()) :: no_return()
   def notify(%Event{} = event),
     do: GenServer.cast(__MODULE__, {:notify, event})
 
@@ -28,7 +35,7 @@ defmodule EventBus.Notifier do
   ###########################################################################
 
   @doc false
-  @spec handle_cast({:notify, Event.t}, nil) :: no_return()
+  @spec handle_cast({:notify, Event.t()}, nil) :: no_return()
   def handle_cast({:notify, event}, state) do
     @backend.notify(event)
     {:noreply, state}

--- a/lib/event_bus/services/notifier.ex
+++ b/lib/event_bus/services/notifier.ex
@@ -10,11 +10,11 @@ defmodule EventBus.Service.Notifier do
   @logging_level :info
 
   @doc false
-  @spec notify(Event.t) :: no_return()
+  @spec notify(Event.t()) :: no_return()
   def notify(%Event{id: id, topic: topic} = event) do
     listeners = Subscription.subscribers(topic)
-    :ok       = Store.save(event)
-    :ok       = Watcher.create({listeners, topic, id})
+    :ok = Store.save(event)
+    :ok = Watcher.create({listeners, topic, id})
 
     notify_listeners(listeners, {topic, id})
   end
@@ -37,6 +37,7 @@ defmodule EventBus.Service.Notifier do
       log(listener, error)
       Watcher.mark_as_skipped({{listener, config}, topic, id})
   end
+
   defp notify_listener(listener, {topic, id}) do
     listener.process({topic, id})
   rescue

--- a/lib/event_bus/services/store.ex
+++ b/lib/event_bus/services/store.ex
@@ -7,10 +7,11 @@ defmodule EventBus.Service.Store do
   @prefix "eb_es_"
 
   @doc false
-  @spec register_topic(String.t | atom()) :: no_return()
+  @spec register_topic(String.t() | atom()) :: no_return()
   def register_topic(topic) do
     table_name = table_name(topic)
     all_tables = :ets.all()
+
     unless Enum.any?(all_tables, fn table -> table == table_name end) do
       opts = [:set, :public, :named_table, {:read_concurrency, true}]
       Ets.new(table_name, opts)
@@ -18,17 +19,18 @@ defmodule EventBus.Service.Store do
   end
 
   @doc false
-  @spec unregister_topic(String.t | atom()) :: no_return()
+  @spec unregister_topic(String.t() | atom()) :: no_return()
   def unregister_topic(topic) do
     table_name = table_name(topic)
     all_tables = :ets.all()
+
     if Enum.any?(all_tables, fn table -> table == table_name end) do
       Ets.delete(table_name)
     end
   end
 
   @doc false
-  @spec fetch({atom(), String.t | integer()}) :: any()
+  @spec fetch({atom(), String.t() | integer()}) :: any()
   def fetch({topic, id}) do
     case Ets.lookup(table_name(topic), id) do
       [{_, %Event{} = event}] -> event
@@ -37,13 +39,13 @@ defmodule EventBus.Service.Store do
   end
 
   @doc false
-  @spec delete({atom(), String.t | integer()}) :: no_return()
+  @spec delete({atom(), String.t() | integer()}) :: no_return()
   def delete({topic, id}) do
     Ets.delete(table_name(topic), id)
   end
 
   @doc false
-  @spec save(Event.t) :: no_return()
+  @spec save(Event.t()) :: no_return()
   def save(%Event{id: id, topic: topic} = event) do
     Ets.insert(table_name(topic), {id, event})
     :ok

--- a/lib/event_bus/services/subscription.ex
+++ b/lib/event_bus/services/subscription.ex
@@ -12,6 +12,7 @@ defmodule EventBus.Service.Subscription do
   def subscribe({listener, topics}) do
     {listeners, topic_map} = load_state()
     listeners = add_or_update_listener(listeners, {listener, topics})
+
     topic_map =
       topic_map
       |> add_listener_to_topic_map({listener, topics})
@@ -25,6 +26,7 @@ defmodule EventBus.Service.Subscription do
   def unsubscribe(listener) do
     {listeners, topic_map} = load_state()
     listeners = List.keydelete(listeners, listener, 0)
+
     topic_map =
       topic_map
       |> remove_listener_from_topic_map(listener)
@@ -34,11 +36,12 @@ defmodule EventBus.Service.Subscription do
   end
 
   @doc false
-  @spec register_topic(String.t | atom()) :: no_return()
+  @spec register_topic(String.t() | atom()) :: no_return()
   def register_topic(topic) do
     {listeners, topic_map} = load_state()
+
     topic_subscribers =
-      Enum.reduce(listeners, [], fn({listener, topics}, acc) ->
+      Enum.reduce(listeners, [], fn {listener, topics}, acc ->
         if RegexUtil.superset?(topics, topic), do: [listener | acc], else: acc
       end)
 
@@ -46,7 +49,7 @@ defmodule EventBus.Service.Subscription do
   end
 
   @doc false
-  @spec unregister_topic(String.t | atom()) :: no_return()
+  @spec unregister_topic(String.t() | atom()) :: no_return()
   def unregister_topic(topic) do
     {listeners, topic_map} = load_state()
     save_state({listeners, Map.drop(topic_map, [topic])})
@@ -57,6 +60,7 @@ defmodule EventBus.Service.Subscription do
     {listeners, _topic_map} = load_state()
     listeners
   end
+
   def subscribers(topic) do
     {_listeners, topic_map} = load_state()
     topic_map[topic] || []
@@ -72,6 +76,7 @@ defmodule EventBus.Service.Subscription do
   defp add_listener_to_topic_map(topic_map, {listener, topics}) do
     Enum.map(topic_map, fn {topic, topic_listeners} ->
       topic_listeners = List.delete(topic_listeners, listener)
+
       if RegexUtil.superset?(topics, topic) do
         {topic, [listener | topic_listeners]}
       else
@@ -96,6 +101,7 @@ defmodule EventBus.Service.Subscription do
 
   defp init_topic_map do
     topics = Topic.all()
+
     topics
     |> Enum.map(fn topic -> {topic, []} end)
     |> Enum.into(%{})

--- a/lib/event_bus/services/topic.ex
+++ b/lib/event_bus/services/topic.ex
@@ -15,7 +15,7 @@ defmodule EventBus.Service.Topic do
     do: Application.get_env(:event_bus, :topics, [])
 
   @doc false
-  @spec exist?(String.t | atom()) :: boolean()
+  @spec exist?(String.t() | atom()) :: boolean()
   def exist?(topic),
     do: Enum.any?(all(), fn event_topic -> event_topic == :"#{topic}" end)
 
@@ -28,10 +28,11 @@ defmodule EventBus.Service.Topic do
   end
 
   @doc false
-  @spec register(String.t | atom()) :: no_return()
+  @spec register(String.t() | atom()) :: no_return()
   def register(topic) do
-    topic  = :"#{topic}"
+    topic = :"#{topic}"
     topics = all()
+
     unless Enum.member?(topics, topic) do
       Application.put_env(@app, @namespace, [topic | topics], persistent: true)
       Enum.each(@modules, fn mod -> mod.register_topic(topic) end)
@@ -39,10 +40,11 @@ defmodule EventBus.Service.Topic do
   end
 
   @doc false
-  @spec unregister(String.t | atom()) :: no_return()
+  @spec unregister(String.t() | atom()) :: no_return()
   def unregister(topic) do
-    topic  = :"#{topic}"
+    topic = :"#{topic}"
     topics = all()
+
     if Enum.member?(topics, topic) do
       Enum.each(@modules, fn mod -> mod.unregister_topic(topic) end)
       topics = List.delete(topics, topic)

--- a/lib/event_bus/services/watcher.ex
+++ b/lib/event_bus/services/watcher.ex
@@ -7,22 +7,30 @@ defmodule EventBus.Service.Watcher do
   @prefix "eb_ew_"
 
   @doc false
-  @spec register_topic(String.t | atom()) :: no_return()
+  @spec register_topic(String.t() | atom()) :: no_return()
   def register_topic(topic) do
     table_name = table_name(topic)
     all_tables = :ets.all()
+
     unless Enum.any?(all_tables, fn table -> table == table_name end) do
-      opts = [:set, :public, :named_table, {:write_concurrency, true},
-        {:read_concurrency, true}]
+      opts = [
+        :set,
+        :public,
+        :named_table,
+        {:write_concurrency, true},
+        {:read_concurrency, true}
+      ]
+
       Ets.new(table_name, opts)
     end
   end
 
   @doc false
-  @spec unregister_topic(String.t | atom()) :: no_return()
+  @spec unregister_topic(String.t() | atom()) :: no_return()
   def unregister_topic(topic) do
     table_name = table_name(topic)
     all_tables = :ets.all()
+
     if Enum.any?(all_tables, fn table -> table == table_name end) do
       Ets.delete(table_name)
     end
@@ -32,16 +40,14 @@ defmodule EventBus.Service.Watcher do
   @spec mark_as_completed(tuple()) :: no_return()
   def mark_as_completed({listener, topic, id}) do
     {listeners, completers, skippers} = fetch({topic, id})
-    save_or_delete({topic, id}, {listeners, [listener | completers],
-      skippers})
+    save_or_delete({topic, id}, {listeners, [listener | completers], skippers})
   end
 
   @doc false
   @spec mark_as_skipped(tuple()) :: no_return()
   def mark_as_skipped({listener, topic, id}) do
     {listeners, completers, skippers} = fetch({topic, id})
-    save_or_delete({topic, id}, {listeners, completers,
-      [listener | skippers]})
+    save_or_delete({topic, id}, {listeners, completers, [listener | skippers]})
   end
 
   @doc false
@@ -79,7 +85,7 @@ defmodule EventBus.Service.Watcher do
     Ets.delete(table_name(topic), id)
   end
 
-  @spec table_name(String.t | atom()) :: atom()
+  @spec table_name(String.t() | atom()) :: atom()
   defp table_name(name),
     do: :"#{@prefix}#{name}"
 end

--- a/lib/event_bus/store.ex
+++ b/lib/event_bus/store.ex
@@ -10,38 +10,45 @@ defmodule EventBus.Store do
   use GenServer
   alias EventBus.Model.Event
 
-  @backend Application.get_env(:event_bus, :store_backend,
-    EventBus.Service.Store)
+  @backend Application.get_env(
+             :event_bus,
+             :store_backend,
+             EventBus.Service.Store
+           )
 
   @doc false
   def start_link,
     do: GenServer.start_link(__MODULE__, nil, name: __MODULE__)
 
+  @doc false
+  def init(args),
+    do: {:ok, args}
+
   @doc """
   Register a topic to the store
   """
-  @spec register_topic(String.t | atom()) :: no_return()
+  @spec register_topic(String.t() | atom()) :: no_return()
   def register_topic(topic),
     do: GenServer.cast(__MODULE__, {:register_topic, topic})
 
   @doc """
   Unregister the topic from the store
   """
-  @spec unregister_topic(String.t | atom()) :: no_return()
+  @spec unregister_topic(String.t() | atom()) :: no_return()
   def unregister_topic(topic),
     do: GenServer.cast(__MODULE__, {:unregister_topic, topic})
 
   @doc """
   Delete an event from the store
   """
-  @spec delete({atom(), String.t | integer()}) :: no_return()
+  @spec delete({atom(), String.t() | integer()}) :: no_return()
   def delete({topic, id}),
     do: GenServer.cast(__MODULE__, {:delete, {topic, id}})
 
   @doc """
   Save an event to the store
   """
-  @spec save(Event.t) :: :ok
+  @spec save(Event.t()) :: :ok
   def save(%Event{} = event),
     do: GenServer.call(__MODULE__, {:save, event})
 
@@ -52,26 +59,30 @@ defmodule EventBus.Store do
   @doc """
   Fetch an event from the store
   """
-  @spec fetch({atom(), String.t | integer()}) :: any()
+  @spec fetch({atom(), String.t() | integer()}) :: any()
   defdelegate fetch(event_shadow),
-    to: @backend, as: :fetch
+    to: @backend,
+    as: :fetch
 
   ###########################################################################
   # PRIVATE API
   ###########################################################################
 
   @doc false
-  @spec handle_cast({:register_topic, String.t | atom()}, nil) :: no_return()
+  @spec handle_cast({:register_topic, String.t() | atom()}, nil) :: no_return()
   def handle_cast({:register_topic, topic}, state) do
     @backend.register_topic(topic)
     {:noreply, state}
   end
-  @spec handle_cast({:unregister_topic, String.t | atom()}, nil) :: no_return()
+
+  @spec handle_cast({:unregister_topic, String.t() | atom()}, nil)
+    :: no_return()
   def handle_cast({:unregister_topic, topic}, state) do
     @backend.unregister_topic(topic)
     {:noreply, state}
   end
-  @spec handle_cast({:delete, {atom(), String.t | integer()}}, nil)
+
+  @spec handle_cast({:delete, {atom(), String.t() | integer()}}, nil)
     :: no_return()
   def handle_cast({:delete, {topic, id}}, state) do
     @backend.delete({topic, id})
@@ -79,7 +90,7 @@ defmodule EventBus.Store do
   end
 
   @doc false
-  @spec handle_call({:save, Event.t}, any(), nil) :: no_return()
+  @spec handle_call({:save, Event.t()}, any(), nil) :: no_return()
   def handle_call({:save, event}, _from, state) do
     @backend.save(event)
     {:reply, :ok, state}

--- a/lib/event_bus/subscription.ex
+++ b/lib/event_bus/subscription.ex
@@ -7,12 +7,19 @@ defmodule EventBus.Subscription do
 
   use GenServer
 
-  @backend Application.get_env(:event_bus, :subscription_backend,
-    EventBus.Service.Subscription)
+  @backend Application.get_env(
+             :event_bus,
+             :subscription_backend,
+             EventBus.Service.Subscription
+           )
 
   @doc false
   def start_link,
     do: GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+
+  @doc false
+  def init(args),
+    do: {:ok, args}
 
   @doc """
   Subscribe the listener to topics
@@ -51,38 +58,44 @@ defmodule EventBus.Subscription do
   """
   @spec subscribers() :: list(any())
   defdelegate subscribers,
-    to: @backend, as: :subscribers
+    to: @backend,
+    as: :subscribers
 
   @doc """
   Fetch listeners of the topic
   """
-  @spec subscribers(String.t | atom()) :: list(any())
+  @spec subscribers(String.t() | atom()) :: list(any())
   defdelegate subscribers(topic),
-    to: @backend, as: :subscribers
+    to: @backend,
+    as: :subscribers
 
   ###########################################################################
   # PRIVATE API
   ###########################################################################
 
   @doc false
+  @spec handle_cast({:subscribe, tuple()}, nil) :: no_return()
   def handle_cast({:subscribe, {listener, topics}}, state) do
     @backend.subscribe({listener, topics})
     {:noreply, state}
   end
 
   @doc false
+  @spec handle_cast({:unsubscribe, tuple() | module()}, nil) :: no_return()
   def handle_cast({:unsubscribe, listener}, state) do
     @backend.unsubscribe(listener)
     {:noreply, state}
   end
 
   @doc false
+  @spec handle_cast({:register_topic, atom()}, nil) :: no_return()
   def handle_cast({:register_topic, topic}, state) do
     @backend.register_topic(topic)
     {:noreply, state}
   end
 
   @doc false
+  @spec handle_cast({:unregister_topic, atom()}, nil) :: no_return()
   def handle_cast({:unregister_topic, topic}, state) do
     @backend.unregister_topic(topic)
     {:noreply, state}

--- a/lib/event_bus/topic.ex
+++ b/lib/event_bus/topic.ex
@@ -7,24 +7,31 @@ defmodule EventBus.Topic do
 
   use GenServer
 
-  @backend Application.get_env(:event_bus, :topic_backend,
-    EventBus.Service.Topic)
+  @backend Application.get_env(
+             :event_bus,
+             :topic_backend,
+             EventBus.Service.Topic
+           )
 
   @doc false
   def start_link,
     do: GenServer.start_link(__MODULE__, nil, name: __MODULE__)
 
+  @doc false
+  def init(args),
+    do: {:ok, args}
+
   @doc """
   Register a topic
   """
-  @spec register(String.t | atom()) :: no_return()
+  @spec register(String.t() | atom()) :: no_return()
   def register(topic),
     do: GenServer.cast(__MODULE__, {:register, topic})
 
   @doc """
   Unregister a topic
   """
-  @spec unregister(String.t | atom()) :: no_return()
+  @spec unregister(String.t() | atom()) :: no_return()
   def unregister(topic),
     do: GenServer.cast(__MODULE__, {:unregister, topic})
 
@@ -37,33 +44,37 @@ defmodule EventBus.Topic do
   """
   @spec all() :: list(atom())
   defdelegate all,
-    to: @backend, as: :all
+    to: @backend,
+    as: :all
 
   @doc """
   Check if the topic exists?
   """
-  @spec exist?(String.t | atom()) :: boolean()
+  @spec exist?(String.t() | atom()) :: boolean()
   defdelegate exist?(topic),
-    to: @backend, as: :exist?
+    to: @backend,
+    as: :exist?
 
   @doc """
   Register all topics from config
   """
   @spec register_from_config() :: no_return()
   defdelegate register_from_config,
-    to: @backend, as: :register_from_config
+    to: @backend,
+    as: :register_from_config
 
   ###########################################################################
   # PRIVATE API
   ###########################################################################
 
   @doc false
-  @spec handle_cast({:register, String.t | atom()}, nil) :: no_return()
+  @spec handle_cast({:register, String.t() | atom()}, nil) :: no_return()
   def handle_cast({:register, topic}, state) do
     @backend.register(topic)
     {:noreply, state}
   end
-  @spec handle_cast({:unregister, String.t | atom()}, nil) :: no_return()
+
+  @spec handle_cast({:unregister, String.t() | atom()}, nil) :: no_return()
   def handle_cast({:unregister, topic}, state) do
     @backend.unregister(topic)
     {:noreply, state}

--- a/lib/event_bus/utils/regex.ex
+++ b/lib/event_bus/utils/regex.ex
@@ -6,17 +6,17 @@ defmodule EventBus.Util.Regex do
   @doc """
   It checks if the given list of keys includes the key
   """
-  @spec superset?(list(String.t | atom()), String.t | atom()) :: boolean()
+  @spec superset?(list(String.t() | atom()), String.t() | atom()) :: boolean()
   def superset?(keys, key) do
     regex_pattern = build_regex_pattern(keys)
 
     case Regex.compile(regex_pattern) do
       {:ok, pattern} -> Regex.match?(pattern, "#{key}")
-      _              -> false
+      _ -> false
     end
   end
 
-  @spec build_regex_pattern(list(String.t | atom())) :: String.t
+  @spec build_regex_pattern(list(String.t() | atom())) :: String.t()
   defp build_regex_pattern(keys) do
     keys
     |> Enum.map(fn key -> "^(#{key})" end)

--- a/lib/event_bus/watcher.ex
+++ b/lib/event_bus/watcher.ex
@@ -10,24 +10,31 @@ defmodule EventBus.Watcher do
 
   use GenServer
 
-  @backend Application.get_env(:event_bus, :watcher_backend,
-    EventBus.Service.Watcher)
+  @backend Application.get_env(
+             :event_bus,
+             :watcher_backend,
+             EventBus.Service.Watcher
+           )
 
   @doc false
   def start_link,
     do: GenServer.start_link(__MODULE__, nil, name: __MODULE__)
 
+  @doc false
+  def init(args),
+    do: {:ok, args}
+
   @doc """
   Register a topic to the watcher
   """
-  @spec register_topic(String.t) :: no_return()
+  @spec register_topic(String.t()) :: no_return()
   def register_topic(topic),
     do: GenServer.cast(__MODULE__, {:register_topic, topic})
 
   @doc """
   Unregister a topic from the watcher
   """
-  @spec unregister_topic(String.t | atom()) :: no_return()
+  @spec unregister_topic(String.t() | atom()) :: no_return()
   def unregister_topic(topic),
     do: GenServer.cast(__MODULE__, {:unregister_topic, topic})
 
@@ -59,31 +66,36 @@ defmodule EventBus.Watcher do
   @doc """
   Fetch the watcher
   """
-  @spec fetch({atom(), String.t | integer()}) :: tuple() | nil
+  @spec fetch({atom(), String.t() | integer()}) :: tuple() | nil
   defdelegate fetch(event_shadow),
-    to: @backend, as: :fetch
+    to: @backend,
+    as: :fetch
 
   ###########################################################################
   # PRIVATE API
   ###########################################################################
 
   @doc false
-  @spec handle_cast({:register_topic, String.t | atom()}, nil) :: no_return()
+  @spec handle_cast({:register_topic, String.t() | atom()}, nil) :: no_return()
   def handle_cast({:register_topic, topic}, state) do
     @backend.register_topic(topic)
     {:noreply, state}
   end
-  @spec handle_cast({:unregister_topic, String.t | atom()}, nil) :: no_return()
+
+  @spec handle_cast({:unregister_topic, String.t() | atom()}, nil)
+    :: no_return()
   def handle_cast({:unregister_topic, topic}, state) do
     @backend.unregister_topic(topic)
     {:noreply, state}
   end
+
   @doc false
   @spec handle_cast({:mark_as_completed, tuple()}, nil) :: no_return()
   def handle_cast({:mark_as_completed, {listener, topic, id}}, state) do
     @backend.mark_as_completed({listener, topic, id})
     {:noreply, state}
   end
+
   @doc false
   @spec handle_cast({:mark_as_skipped, tuple()}, nil) :: no_return()
   def handle_cast({:mark_as_skipped, {listener, topic, id}}, state) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,18 +2,20 @@ defmodule EventBus.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :event_bus,
-     version: "1.0.0-beta3",
-     elixir: "~> 1.5",
-     elixirc_paths: elixirc_paths(Mix.env),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     dialyzer: [plt_add_deps: :transitive],
-     test_coverage: [tool: ExCoveralls],
-     docs: [extras: ["README.md"]]]
+    [
+      app: :event_bus,
+      version: "1.0.0-beta3",
+      elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      dialyzer: [plt_add_deps: :transitive],
+      test_coverage: [tool: ExCoveralls],
+      docs: [extras: ["README.md"]]
+    ]
   end
 
   # Configuration for the OTP application
@@ -21,14 +23,11 @@ defmodule EventBus.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger],
-     mod: {EventBus.Application, []}]
+    [extra_applications: [:logger], mod: {EventBus.Application, []}]
   end
 
-  defp elixirc_paths(:test),
-    do: ["lib", "test/support"]
-  defp elixirc_paths(_),
-    do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Dependencies can be Hex packages:
   #
@@ -55,10 +54,12 @@ defmodule EventBus.Mixfile do
   end
 
   defp package do
-    [name: :event_bus,
-     files: ["lib", "mix.exs", "README.md"],
-     maintainers: ["Mustafa Turan"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/mustafaturan/event_bus"}]
+    [
+      name: :event_bus,
+      files: ["lib", "mix.exs", "README.md"],
+      maintainers: ["Mustafa Turan"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/mustafaturan/event_bus"}
+    ]
   end
 end

--- a/test/event_bus/event_source_test.exs
+++ b/test/event_bus/event_source_test.exs
@@ -11,7 +11,7 @@ defmodule EventBus.EventSourceTest do
 
   test "build with source" do
     id             = 1
-    topic          = "user_created"
+    topic          = :user_created
     data           = %{id: 1, name: "me", email: "me@example.com"}
     transaction_id = "t1"
     ttl            = 100
@@ -34,7 +34,7 @@ defmodule EventBus.EventSourceTest do
 
   test "build without source" do
     id             = 1
-    topic          = "user_created"
+    topic          = :user_created
     data           = %{id: 1, name: "me", email: "me@example.com"}
     transaction_id = "t1"
     ttl            = 100
@@ -55,9 +55,33 @@ defmodule EventBus.EventSourceTest do
     refute is_nil(event.occurred_at)
   end
 
+  test "build with error topic" do
+    id             = 1
+    topic          = :user_created
+    error_topic    = :user_create_erred
+    data           = %{email: "Invalid format"}
+    transaction_id = "t1"
+    ttl            = 100
+
+    event =
+      EventSource.build(%{id: id, topic: topic, transaction_id: transaction_id,
+        ttl: ttl, error_topic: error_topic}) do
+        {:error, data}
+      end
+
+    assert event.data == {:error, data}
+    assert event.id == id
+    assert event.topic == error_topic
+    assert event.transaction_id == transaction_id
+    assert event.ttl == ttl
+    assert event.source == "Elixir.EventBus.EventSourceTest"
+    refute is_nil(event.initialized_at)
+    refute is_nil(event.occurred_at)
+  end
+
   test "notify" do
     id     = 1
-    topic  = "user_created"
+    topic  = :user_created
     data   = %{id: 1, name: "me", email: "me@example.com"}
     result =
       EventSource.notify(%{id: id, topic: topic}) do

--- a/test/event_bus/event_source_test.exs
+++ b/test/event_bus/event_source_test.exs
@@ -10,15 +10,20 @@ defmodule EventBus.EventSourceTest do
   end
 
   test "build with source" do
-    id             = 1
-    topic          = :user_created
-    data           = %{id: 1, name: "me", email: "me@example.com"}
+    id = 1
+    topic = :user_created
+    data = %{id: 1, name: "me", email: "me@example.com"}
     transaction_id = "t1"
-    ttl            = 100
+    ttl = 100
 
     event =
-      EventSource.build(%{id: id, topic: topic, transaction_id: transaction_id,
-        ttl: ttl, source: "me"}) do
+      EventSource.build %{
+        id: id,
+        topic: topic,
+        transaction_id: transaction_id,
+        ttl: ttl,
+        source: "me"
+      } do
         data
       end
 
@@ -33,15 +38,19 @@ defmodule EventBus.EventSourceTest do
   end
 
   test "build without source" do
-    id             = 1
-    topic          = :user_created
-    data           = %{id: 1, name: "me", email: "me@example.com"}
+    id = 1
+    topic = :user_created
+    data = %{id: 1, name: "me", email: "me@example.com"}
     transaction_id = "t1"
-    ttl            = 100
+    ttl = 100
 
     event =
-      EventSource.build(%{id: id, topic: topic, transaction_id: transaction_id,
-        ttl: ttl}) do
+      EventSource.build %{
+        id: id,
+        topic: topic,
+        transaction_id: transaction_id,
+        ttl: ttl
+      } do
         data
       end
 
@@ -50,22 +59,27 @@ defmodule EventBus.EventSourceTest do
     assert event.topic == topic
     assert event.transaction_id == transaction_id
     assert event.ttl == ttl
-    assert event.source == "Elixir.EventBus.EventSourceTest"
+    assert event.source == "EventBus.EventSourceTest"
     refute is_nil(event.initialized_at)
     refute is_nil(event.occurred_at)
   end
 
   test "build with error topic" do
-    id             = 1
-    topic          = :user_created
-    error_topic    = :user_create_erred
-    data           = %{email: "Invalid format"}
+    id = 1
+    topic = :user_created
+    error_topic = :user_create_erred
+    data = %{email: "Invalid format"}
     transaction_id = "t1"
-    ttl            = 100
+    ttl = 100
 
     event =
-      EventSource.build(%{id: id, topic: topic, transaction_id: transaction_id,
-        ttl: ttl, error_topic: error_topic}) do
+      EventSource.build %{
+        id: id,
+        topic: topic,
+        transaction_id: transaction_id,
+        ttl: ttl,
+        error_topic: error_topic
+      } do
         {:error, data}
       end
 
@@ -74,17 +88,18 @@ defmodule EventBus.EventSourceTest do
     assert event.topic == error_topic
     assert event.transaction_id == transaction_id
     assert event.ttl == ttl
-    assert event.source == "Elixir.EventBus.EventSourceTest"
+    assert event.source == "EventBus.EventSourceTest"
     refute is_nil(event.initialized_at)
     refute is_nil(event.occurred_at)
   end
 
   test "notify" do
-    id     = 1
-    topic  = :user_created
-    data   = %{id: 1, name: "me", email: "me@example.com"}
+    id = 1
+    topic = :user_created
+    data = %{id: 1, name: "me", email: "me@example.com"}
+
     result =
-      EventSource.notify(%{id: id, topic: topic}) do
+      EventSource.notify %{id: id, topic: topic} do
         data
       end
 

--- a/test/event_bus/models/event_test.exs
+++ b/test/event_bus/models/event_test.exs
@@ -12,24 +12,27 @@ defmodule EventBus.Model.EventTest do
 
   test "duration" do
     initialized_at = System.os_time(:micro_seconds)
-    Process.sleep(1) # do sth in this frame
+    # do sth in this frame
+    Process.sleep(1)
 
     event = %Event{
-      id:             1,
-      topic:          "user_created",
-      data:           %{id: 1, name: "me", email: "me@example.com"},
+      id: 1,
+      topic: "user_created",
+      data: %{id: 1, name: "me", email: "me@example.com"},
       initialized_at: initialized_at,
-      occurred_at:    System.os_time(:micro_seconds)
+      occurred_at: System.os_time(:micro_seconds)
     }
+
     assert Event.duration(event) > 0
   end
 
   test "duration should return 0 if initialized_at and/or occurred_at is nil" do
     event = %Event{
-      id:    1,
+      id: 1,
       topic: "user_created",
-      data:  %{id: 1, name: "me", email: "me@example.com"}
+      data: %{id: 1, name: "me", email: "me@example.com"}
     }
+
     assert Event.duration(event) == 0
   end
 end

--- a/test/event_bus/notifier_test.exs
+++ b/test/event_bus/notifier_test.exs
@@ -6,8 +6,13 @@ defmodule EventBus.NotifierTest do
   doctest Notifier
 
   @topic :metrics_received
-  @event %Event{id: "E1", transaction_id: "T1", topic: @topic, data: [1, 2],
-    source: "NotifierTest"}
+  @event %Event{
+    id: "E1",
+    transaction_id: "T1",
+    topic: @topic,
+    data: [1, 2],
+    source: "NotifierTest"
+  }
 
   setup do
     refute is_nil(Process.whereis(Notifier))

--- a/test/event_bus/services/notifier_test.exs
+++ b/test/event_bus/services/notifier_test.exs
@@ -14,6 +14,16 @@ defmodule EventBus.Service.NotifierTest do
     source: "NotifierTest"}
 
   setup do
+    on_exit fn ->
+      Subscription.unregister_topic(:metrics_received)
+      Subscription.unregister_topic(:metrics_summed)
+      Process.sleep(100)
+    end
+
+    Subscription.register_topic(:metrics_received)
+    Subscription.register_topic(:metrics_summed)
+    Process.sleep(100)
+
     for subscriber <- Subscription.subscribers() do
       Subscription.unsubscribe(subscriber)
     end
@@ -32,7 +42,7 @@ defmodule EventBus.Service.NotifierTest do
     # This processor/listener one has one config!!!
     Subscription.subscribe({AnotherCalculator, ["metrics_received$"]})
 
-    Process.sleep(300) # Sleep until subscriptions complete
+    Process.sleep(400) # Sleep until subscriptions complete
 
     logs =
       capture_log(fn ->

--- a/test/event_bus/services/store_test.exs
+++ b/test/event_bus/services/store_test.exs
@@ -32,8 +32,12 @@ defmodule EventBus.Service.StoreTest do
     Store.register_topic(topic)
     Process.sleep(100)
 
-    event = %Event{id: "E1", transaction_id: "T1", data: ["Mustafa", "Turan"],
-      topic: topic}
+    event = %Event{
+      id: "E1",
+      transaction_id: "T1",
+      data: ["Mustafa", "Turan"],
+      topic: topic
+    }
 
     assert :ok == Store.save(event)
   end
@@ -43,10 +47,19 @@ defmodule EventBus.Service.StoreTest do
     Store.register_topic(topic)
     Process.sleep(100)
 
-    first_event = %Event{id: "E1", transaction_id: "T1",
-      data: ["Mustafa", "Turan"], topic: topic}
-    second_event = %Event{id: "E2", transaction_id: "T1",
-      data: %{name: "Mustafa", surname: "Turan"}, topic: topic}
+    first_event = %Event{
+      id: "E1",
+      transaction_id: "T1",
+      data: ["Mustafa", "Turan"],
+      topic: topic
+    }
+
+    second_event = %Event{
+      id: "E2",
+      transaction_id: "T1",
+      data: %{name: "Mustafa", surname: "Turan"},
+      topic: topic
+    }
 
     :ok = Store.save(first_event)
     :ok = Store.save(second_event)
@@ -60,8 +73,12 @@ defmodule EventBus.Service.StoreTest do
     Store.register_topic(topic)
     Process.sleep(100)
 
-    event = %Event{id: "E1", transaction_id: "T1", data: ["Mustafa", "Turan"],
-      topic: topic}
+    event = %Event{
+      id: "E1",
+      transaction_id: "T1",
+      data: ["Mustafa", "Turan"],
+      topic: topic
+    }
 
     :ok = Store.save(event)
     Store.delete({topic, event.id})

--- a/test/event_bus/services/subscription_test.exs
+++ b/test/event_bus/services/subscription_test.exs
@@ -9,11 +9,21 @@ defmodule EventBus.Service.SubscriptionTest do
   setup do
     on_exit fn ->
       Subscription.unregister_topic(:auto_subscribed)
+      Subscription.unregister_topic(:metrics_received)
+      Subscription.unregister_topic(:metrics_summed)
+      Process.sleep(100)
     end
+
+    Subscription.register_topic(:auto_subscribed)
+    Subscription.register_topic(:metrics_received)
+    Subscription.register_topic(:metrics_summed)
+    Process.sleep(100)
 
     for {subscriber, _topics} <- Subscription.subscribers() do
       Subscription.unsubscribe(subscriber)
     end
+
+    Process.sleep(100)
     :ok
   end
 
@@ -124,8 +134,10 @@ defmodule EventBus.Service.SubscriptionTest do
       ],
       %{
         metrics_received: [AnotherCalculator, {InputLogger, %{}}],
-        metrics_summed: [{InputLogger, %{}}]}
+        metrics_summed: [{InputLogger, %{}}],
+        auto_subscribed: []
       }
+    }
 
     assert expected == Application.get_env(:event_bus, :subscriptions)
   end

--- a/test/event_bus/services/subscription_test.exs
+++ b/test/event_bus/services/subscription_test.exs
@@ -1,18 +1,24 @@
 defmodule EventBus.Service.SubscriptionTest do
   use ExUnit.Case, async: false
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
-    AnotherCalculator}
+
+  alias EventBus.Support.Helper.{
+    InputLogger,
+    Calculator,
+    MemoryLeakerOne,
+    AnotherCalculator
+  }
+
   alias EventBus.Service.Subscription
 
   doctest Subscription
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Subscription.unregister_topic(:auto_subscribed)
       Subscription.unregister_topic(:metrics_received)
       Subscription.unregister_topic(:metrics_summed)
       Process.sleep(100)
-    end
+    end)
 
     Subscription.register_topic(:auto_subscribed)
     Subscription.register_topic(:metrics_received)
@@ -35,11 +41,11 @@ defmodule EventBus.Service.SubscriptionTest do
     Process.sleep(300)
 
     assert [
-      {AnotherCalculator, [".*"]},
-      {{MemoryLeakerOne, %{}}, [".*"]},
-      {{Calculator, %{}}, [".*"]},
-      {{InputLogger, %{}}, [".*"]}
-    ] == Subscription.subscribers()
+             {AnotherCalculator, [".*"]},
+             {{MemoryLeakerOne, %{}}, [".*"]},
+             {{Calculator, %{}}, [".*"]},
+             {{InputLogger, %{}}, [".*"]}
+           ] == Subscription.subscribers()
   end
 
   test "does not subscribe same listener" do
@@ -61,7 +67,7 @@ defmodule EventBus.Service.SubscriptionTest do
     Process.sleep(300)
 
     assert [{{MemoryLeakerOne, %{}}, [".*"]}, {{InputLogger, %{}}, [".*"]}] ==
-      Subscription.subscribers()
+             Subscription.subscribers()
   end
 
   test "register_topic auto subscribe workers" do
@@ -77,7 +83,7 @@ defmodule EventBus.Service.SubscriptionTest do
     Process.sleep(300)
 
     assert [{InputLogger, %{}}, {Calculator, %{}}, AnotherCalculator] ==
-      Subscription.subscribers(topic)
+             Subscription.subscribers(topic)
   end
 
   test "unregister_topic delete subscribers" do
@@ -106,27 +112,26 @@ defmodule EventBus.Service.SubscriptionTest do
     Subscription.subscribe({{InputLogger, %{}}, [".*"]})
     Process.sleep(300)
 
-    assert [{InputLogger, %{}}] ==
-      Subscription.subscribers(:metrics_received)
-    assert [{InputLogger, %{}}] ==
-      Subscription.subscribers(:metrics_summed)
+    assert [{InputLogger, %{}}] == Subscription.subscribers(:metrics_received)
+    assert [{InputLogger, %{}}] == Subscription.subscribers(:metrics_summed)
   end
 
   test "subscribers with event type and without config" do
     Subscription.subscribe({AnotherCalculator, [".*"]})
     Process.sleep(300)
 
-    assert [AnotherCalculator] ==
-      Subscription.subscribers(:metrics_received)
-    assert [AnotherCalculator] ==
-      Subscription.subscribers(:metrics_summed)
+    assert [AnotherCalculator] == Subscription.subscribers(:metrics_received)
+    assert [AnotherCalculator] == Subscription.subscribers(:metrics_summed)
   end
 
   test "state persistency to Application environment" do
-    Subscription.subscribe({{InputLogger, %{}}, ["metrics_received",
-      "metrics_summed"]})
+    Subscription.subscribe(
+      {{InputLogger, %{}}, ["metrics_received", "metrics_summed"]}
+    )
+
     Subscription.subscribe({AnotherCalculator, ["metrics_received$"]})
     Process.sleep(300)
+
     expected = {
       [
         {AnotherCalculator, ["metrics_received$"]},

--- a/test/event_bus/services/topic_test.exs
+++ b/test/event_bus/services/topic_test.exs
@@ -5,11 +5,11 @@ defmodule EventBus.Service.TopicTest do
   doctest Topic
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Topic.unregister(:t1)
       Topic.unregister(:t2)
       Topic.unregister(:t3)
-    end
+    end)
 
     :ok
   end
@@ -57,10 +57,10 @@ defmodule EventBus.Service.TopicTest do
   end
 
   test "exist? with an existent topic" do
-    assert Topic.exist? :metrics_received
+    assert Topic.exist?(:metrics_received)
   end
 
   test "exist? with a non-existent topic" do
-    refute Topic.exist? :unknown_called
+    refute Topic.exist?(:unknown_called)
   end
 end

--- a/test/event_bus/services/watcher_test.exs
+++ b/test/event_bus/services/watcher_test.exs
@@ -1,8 +1,13 @@
 defmodule EventBus.Service.WatcherTest do
   use ExUnit.Case, async: false
   alias EventBus.Service.Watcher
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
-    BadOne}
+
+  alias EventBus.Support.Helper.{
+    InputLogger,
+    Calculator,
+    MemoryLeakerOne,
+    BadOne
+  }
 
   doctest Watcher
 
@@ -30,10 +35,15 @@ defmodule EventBus.Service.WatcherTest do
   end
 
   test "create and fetch" do
-    topic      = :some_event_occurred1
-    id         = "E1"
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    topic = :some_event_occurred1
+    id = "E1"
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
     Process.sleep(100)
@@ -44,10 +54,15 @@ defmodule EventBus.Service.WatcherTest do
   end
 
   test "complete" do
-    topic      = :some_event_occurred2
-    id         = "E1"
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    topic = :some_event_occurred2
+    id = "E1"
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
     Process.sleep(100)
@@ -56,15 +71,19 @@ defmodule EventBus.Service.WatcherTest do
     Watcher.mark_as_completed({{InputLogger, %{}}, topic, id})
     Process.sleep(100)
 
-    assert {processors, [{InputLogger, %{}}], []} ==
-      Watcher.fetch({topic, id})
+    assert {processors, [{InputLogger, %{}}], []} == Watcher.fetch({topic, id})
   end
 
   test "skip" do
-    id         = "E1"
-    topic      = :some_event_occurred3
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    id = "E1"
+    topic = :some_event_occurred3
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
     Process.sleep(100)
@@ -73,7 +92,6 @@ defmodule EventBus.Service.WatcherTest do
     Watcher.mark_as_skipped({{InputLogger, %{}}, topic, id})
     Process.sleep(100)
 
-    assert {processors, [], [{InputLogger, %{}}]} ==
-      Watcher.fetch({topic, id})
+    assert {processors, [], [{InputLogger, %{}}]} == Watcher.fetch({topic, id})
   end
 end

--- a/test/event_bus/subscription_test.exs
+++ b/test/event_bus/subscription_test.exs
@@ -6,9 +6,9 @@ defmodule EventBus.SubscriptionTest do
   doctest Subscription
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Subscription.unregister_topic(:auto_subscribed)
-    end
+    end)
 
     for {subscriber, _topics} <- Subscription.subscribers() do
       Subscription.unsubscribe(subscriber)

--- a/test/event_bus/topic_test.exs
+++ b/test/event_bus/topic_test.exs
@@ -5,10 +5,10 @@ defmodule EventBus.TopicTest do
   doctest EventBus.Topic
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Topic.unregister(:t1)
       Topic.unregister(:t2)
-    end
+    end)
 
     :ok
   end

--- a/test/event_bus/watcher_test.exs
+++ b/test/event_bus/watcher_test.exs
@@ -1,8 +1,14 @@
 defmodule EventBus.WatcherTest do
   use ExUnit.Case, async: false
   alias EventBus.Watcher
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
-    BadOne}
+
+  alias EventBus.Support.Helper.{
+    InputLogger,
+    Calculator,
+    MemoryLeakerOne,
+    BadOne
+  }
+
   doctest EventBus.Watcher
 
   setup do
@@ -21,10 +27,15 @@ defmodule EventBus.WatcherTest do
   end
 
   test "create" do
-    topic      = :some_event_occurred1
-    id         = "E1"
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    topic = :some_event_occurred1
+    id = "E1"
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
 
@@ -32,10 +43,15 @@ defmodule EventBus.WatcherTest do
   end
 
   test "complete" do
-    topic      = :some_event_occurred2
-    id         = "E1"
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    topic = :some_event_occurred2
+    id = "E1"
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
     Watcher.create({processors, topic, id})
@@ -44,10 +60,15 @@ defmodule EventBus.WatcherTest do
   end
 
   test "skip" do
-    topic      = :some_event_occurred3
-    id         = "E1"
-    processors = [{InputLogger, %{}}, {Calculator, %{}}, {MemoryLeakerOne, %{}},
-      {BadOne, %{}}]
+    topic = :some_event_occurred3
+    id = "E1"
+
+    processors = [
+      {InputLogger, %{}},
+      {Calculator, %{}},
+      {MemoryLeakerOne, %{}},
+      {BadOne, %{}}
+    ]
 
     Watcher.register_topic(topic)
     Watcher.create({processors, topic, id})

--- a/test/event_bus_test.exs
+++ b/test/event_bus_test.exs
@@ -2,17 +2,29 @@ defmodule EventBusTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
   alias EventBus.Model.Event
-  alias EventBus.Support.Helper.{InputLogger, Calculator, MemoryLeakerOne,
-    BadOne}
+
+  alias EventBus.Support.Helper.{
+    InputLogger,
+    Calculator,
+    MemoryLeakerOne,
+    BadOne
+  }
+
   doctest EventBus.Notifier
 
-  @event %Event{id: "M1", transaction_id: "T1", data: [1, 7],
-    topic: :metrics_received, source: "EventBusTest"}
+  @event %Event{
+    id: "M1",
+    transaction_id: "T1",
+    data: [1, 7],
+    topic: :metrics_received,
+    source: "EventBusTest"
+  }
 
   setup do
     for subscriber <- EventBus.subscribers() do
       EventBus.unsubscribe(subscriber)
     end
+
     :ok
   end
 
@@ -21,22 +33,32 @@ defmodule EventBusTest do
     EventBus.subscribe({{BadOne, %{}}, [".*"]})
     EventBus.subscribe({{Calculator, %{}}, ["metrics_received"]})
     EventBus.subscribe({{MemoryLeakerOne, %{}}, [".*"]})
-    Process.sleep(100) # Wait until listeners subscribed to
+    # Wait until listeners subscribed to
+    Process.sleep(100)
 
     logs =
       capture_log(fn ->
         EventBus.notify(@event)
-        Process.sleep(300) # Wait until listeners process events
+        # Wait until listeners process events
+        Process.sleep(300)
       end)
 
     assert String.contains?(logs, "BadOne.process/1 raised an error!")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
-      " [1, 7], id: \"M1\", initialized_at: nil, occurred_at: nil," <>
-      " source: \"EventBusTest\", topic: :metrics_received," <>
-      " transaction_id: \"T1\", ttl: nil}")
-    assert String.contains?(logs, "Event log for %EventBus.Model.Event{data:" <>
-      " {8, [1, 7]}, id: \"E123\", initialized_at: nil, occurred_at: nil," <>
-      " source: \"Logger\", topic: :metrics_summed," <>
-      " transaction_id: \"T1\", ttl: nil}")
+
+    assert String.contains?(
+             logs,
+             "Event log for %EventBus.Model.Event{data:" <>
+               " [1, 7], id: \"M1\", initialized_at: nil, occurred_at: nil," <>
+               " source: \"EventBusTest\", topic: :metrics_received," <>
+               " transaction_id: \"T1\", ttl: nil}"
+           )
+
+    assert String.contains?(
+             logs,
+             "Event log for %EventBus.Model.Event{data:" <>
+               " {8, [1, 7]}, id: \"E123\", initialized_at: nil," <>
+               " occurred_at: nil, source: \"Logger\"," <>
+               " topic: :metrics_summed, transaction_id: \"T1\", ttl: nil}"
+           )
   end
 end

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -20,11 +20,18 @@ defmodule EventBus.Support.Helper do
       # handle an event
       sum = Enum.reduce(inputs, 0, &(&1 + &2))
       # create a new event if necessary
-      new_event = %Event{id: "E123", transaction_id: event.transaction_id,
-        topic: :metrics_summed, data: {sum, inputs}, source: "Logger"}
+      new_event = %Event{
+        id: "E123",
+        transaction_id: event.transaction_id,
+        topic: :metrics_summed,
+        data: {sum, inputs},
+        source: "Logger"
+      }
+
       EventBus.notify(new_event)
       EventBus.mark_as_completed({{__MODULE__, config}, :metrics_received, id})
     end
+
     def process({config, topic, id}) do
       EventBus.mark_as_skipped({{__MODULE__, config}, topic, id})
     end
@@ -39,12 +46,18 @@ defmodule EventBus.Support.Helper do
       # handle an event
       sum = Enum.reduce(inputs, 0, &(&1 + &2))
       # create a new event if necessary
-      new_event = %Event{id: "E123", transaction_id: event.transaction_id,
-        topic: :metrics_summed, data: {sum, inputs},
-        source: "AnotherCalculator"}
+      new_event = %Event{
+        id: "E123",
+        transaction_id: event.transaction_id,
+        topic: :metrics_summed,
+        data: {sum, inputs},
+        source: "AnotherCalculator"
+      }
+
       EventBus.notify(new_event)
       EventBus.mark_as_completed({__MODULE__, :metrics_received, id})
     end
+
     def process({topic, id}) do
       EventBus.mark_as_skipped({__MODULE__, topic, id})
     end
@@ -65,6 +78,7 @@ defmodule EventBus.Support.Helper do
     def process({config, :metrics_summed, id}) do
       GenServer.cast(__MODULE__, {config, :metrics_summed, id})
     end
+
     def process({config, topic, id}) do
       EventBus.mark_as_skipped({{__MODULE__, config}, topic, id})
     end
@@ -79,7 +93,7 @@ defmodule EventBus.Support.Helper do
 
   defmodule BadOne do
     def process(_, _) do
-      throw "bad"
+      throw("bad")
     end
   end
 end


### PR DESCRIPTION
- Add elixir formatter config to format code
- Error topic introduced for dynamic event builder/notifier with `EventSource`. Now you can pass `:error_topic` key, EvetSource automatically check the result of execution block for `{:error, _}` tuple and create an event structure for the given `:error_topic`.
